### PR TITLE
Dockerize to deploy with shinyproxy

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,5 @@ $run_dev.*
 ^LICENSE\.md$
 ^README\.Rmd$
 ^CODE_OF_CONDUCT\.md$
+^Dockerfile$
+^\.dockerignore$

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.RData
+.Rhistory
+.git
+.gitignore
+manifest.json
+rsconnect/
+Rproj.user

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,6 +30,7 @@ Imports:
   tidyr,
   tibble,
   shiny,
+  shinydashboard,
   shinyBS,
   shinyWidgets,
   shinyjs,
@@ -37,8 +38,8 @@ Imports:
   golem
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1
-Suggests:  
+RoxygenNote: 7.1.2
+Suggests: 
   testthat (>= 3.0.0)
 Depends: 
   R (>= 2.10)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM rocker/r-ver:3.6.3
+RUN apt-get update && apt-get install -y  gdal-bin git-core libcurl4-openssl-dev libgdal-dev libgeos-dev libgeos++-dev libgit2-dev libicu-dev libpng-dev libproj-dev libssl-dev libudunits2-dev libxml2-dev make pandoc pandoc-citeproc zlib1g-dev && rm -rf /var/lib/apt/lists/*
+RUN echo "options(repos = c(CRAN = 'https://cran.rstudio.com/'), download.file.method = 'libcurl', Ncpus = 4)" >> /usr/local/lib/R/etc/Rprofile.site
+RUN R -e 'install.packages("remotes")'
+RUN Rscript -e 'remotes::install_version("tibble",upgrade="never", version = "3.1.6")'
+RUN Rscript -e 'remotes::install_version("glue",upgrade="never", version = "1.5.1")'
+RUN Rscript -e 'remotes::install_version("purrr",upgrade="never", version = "0.3.4")'
+RUN Rscript -e 'remotes::install_version("htmltools",upgrade="never", version = "0.5.2")'
+RUN Rscript -e 'remotes::install_version("dplyr",upgrade="never", version = "1.0.7")'
+RUN Rscript -e 'remotes::install_version("ggplot2",upgrade="never", version = "3.3.5")'
+RUN Rscript -e 'remotes::install_version("testthat",upgrade="never", version = "3.1.1")'
+RUN Rscript -e 'remotes::install_version("shiny",upgrade="never", version = "1.7.1")'
+RUN Rscript -e 'remotes::install_version("data.table",upgrade="never", version = "1.14.2")'
+RUN Rscript -e 'remotes::install_version("tidyr",upgrade="never", version = "1.1.4")'
+RUN Rscript -e 'remotes::install_version("leaflet",upgrade="never", version = "2.0.4.1")'
+RUN Rscript -e 'remotes::install_version("golem",upgrade="never", version = "0.3.1")'
+RUN Rscript -e 'remotes::install_version("plotly",upgrade="never", version = "4.10.0")'
+RUN Rscript -e 'remotes::install_version("shinyjs",upgrade="never", version = "2.0.0")'
+RUN Rscript -e 'remotes::install_version("shinyWidgets",upgrade="never", version = "0.6.2")'
+RUN Rscript -e 'remotes::install_version("shinyBS",upgrade="never", version = "0.61")'
+RUN Rscript -e 'remotes::install_version("shinydashboard",upgrade="never", version = "0.7.2")'
+RUN Rscript -e 'remotes::install_version("MortalityLaws",upgrade="never", version = "1.8.5")'
+RUN Rscript -e 'remotes::install_version("sf",upgrade="never", version = "1.0-4")'
+RUN Rscript -e 'remotes::install_version("leaflet.extras",upgrade="never", version = "1.0.0")'
+RUN mkdir /build_zone
+ADD . /build_zone
+WORKDIR /build_zone
+RUN R -e 'remotes::install_local(upgrade="never")'
+RUN rm -rf /build_zone
+EXPOSE 3838
+CMD  ["R", "-e", "options('shiny.port'=3838,shiny.host='0.0.0.0');lemur::run_app()"]

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -81,7 +81,7 @@ ui_home <- function() {
       background-size:100% 100%;
       ',
 
-      HTML(r'(
+      HTML('(
       <p class="my-class">  Infant mortality and life expectancy are reasonable
           indicators of general well-being in a society.</p>
       <p class="my-class">  P. J. O Rourke</p>

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -1,5 +1,0 @@
-# build docker image
-docker build -t lemur /research/git/doug-leasure/lemur/
-
-# run docker container
-docker run -dp 3838:3838 lemur

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -1,0 +1,5 @@
+# build docker image
+docker build -t lemur /research/git/doug-leasure/lemur/
+
+# run docker container
+docker run -dp 3838:3838 lemur

--- a/inst/golem-config.yml
+++ b/inst/golem-config.yml
@@ -1,5 +1,5 @@
 default:
-  golem_name: MortalityCauses
+  golem_name: lemur
   golem_version: 0.0.1
   app_prod: no
 production:

--- a/man/MortalityCauses.Rd
+++ b/man/MortalityCauses.Rd
@@ -6,15 +6,7 @@
 \alias{lemur-package}
 \title{lemur: Life expectancy monitor upscaled in R}
 \description{
-The life expectancy monitoring tool allows the user to selected 
-  mortality changes over the entire lifespan or at specific ages, as well as 
-  for overall mortality or for specific causes of death. For example, how 
-  would life expectancy look if cardiovascular mortality were to be reduced 
-  by 50%? Or how would life expectancy look if infant mortality was eliminated? 
-  The tool facilitates assessing changes and comparisons in life expectancy 
-  under those selected scenarios of mortality change. Furthermore, the tool 
-  lets the user compare cause-of-death profiles and life expectancies across 
-  time, countries and sexes.
+The life expectancy monitoring tool allows the user to selected mortality changes over the entire lifespan or at specific ages, as well as for overall mortality or for specific causes of death. For example, how would life expectancy look if cardiovascular mortality were to be reduced by 50%? Or how would life expectancy look if infant mortality was eliminated? The tool facilitates assessing changes and comparisons in life expectancy under those selected scenarios of mortality change. Furthermore, the tool lets the user compare cause-of-death profiles and life expectancies across time, countries and sexes.
 }
 \details{
 To learn more about the package, start with the vignettes:

--- a/pkg_build.R
+++ b/pkg_build.R
@@ -1,0 +1,23 @@
+# cleanup
+rm(list=ls()); gc(); cat("\014"); try(dev.off(), silent=T);
+
+# working directory
+setwd(dirname(rstudioapi::getSourceEditorContext()$path))
+
+# package documentation
+devtools::document()
+
+# dockerfile
+golem::add_dockerfile_shinyproxy()
+
+# restart R
+rstudioapi::restartSession()
+
+# install from source
+install.packages(getwd(), repo=NULL, type='source')
+
+# run app
+library(lemur)
+lemur::run_app()
+
+


### PR DESCRIPTION
Added a `pkg_build.R` script that uses golem to create a Dockerfile.  

The dockerized app can be deployed using shinyproxy so that the app is more scalable because each user gets their own R environment.  This avoids the need for a Shiny Server Pro license. I successfully tested the app container with shinyproxy running behind nginx as a reverse proxy web server.